### PR TITLE
Add Codex CLI Docker image

### DIFF
--- a/.github/workflows/codex-cli.yml
+++ b/.github/workflows/codex-cli.yml
@@ -1,0 +1,13 @@
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'codex-cli/**'
+      - '.github/workflows/codex-cli.yml'
+
+jobs:
+  build-push:
+    uses: ./.github/workflows/build-push.yml
+    secrets: inherit
+    with:
+      project-folder: codex-cli

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -1,0 +1,50 @@
+# codex-cli
+
+Docker image for [OpenAI Codex CLI](https://github.com/openai/codex), a local coding agent that runs in your terminal.
+
+## Usage
+
+Pull the image:
+
+```sh
+docker pull lasery/codex-cli
+```
+
+Run Codex in the current project directory:
+
+```sh
+docker run --rm -it \
+  -v "$PWD:/workspace" \
+  -v "$HOME/.codex:/home/node/.codex" \
+  -w /workspace \
+  lasery/codex-cli
+```
+
+Run a one-off prompt:
+
+```sh
+docker run --rm -it \
+  -v "$PWD:/workspace" \
+  -v "$HOME/.codex:/home/node/.codex" \
+  -w /workspace \
+  lasery/codex-cli "explain this repository"
+```
+
+Use an API key instead of the mounted Codex config directory:
+
+```sh
+docker run --rm -it \
+  -e OPENAI_API_KEY \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  lasery/codex-cli
+```
+
+## Build image
+
+```sh
+cd codex-cli
+python3 ~/mbuild/utils/build.py docker
+python3 ~/mbuild/utils/build.py push --only
+python3 ~/mbuild/utils/build.py deploy --only
+```

--- a/codex-cli/mbuild.yml
+++ b/codex-cli/mbuild.yml
@@ -1,0 +1,18 @@
+---
+REPO: codex-cli
+IMAGE_VERSION: latest
+
+ARCH:
+- name: amd64
+  tag: amd64
+  arch: amd64
+  platform: linux/amd64
+  is_amd: true
+  # enable: false
+
+- name: arm64
+  tag: arm64
+  arch: arm64
+  platform: linux/arm64
+  is_arm: true
+  # enable: false

--- a/codex-cli/tmpl.Dockerfile
+++ b/codex-cli/tmpl.Dockerfile
@@ -1,0 +1,27 @@
+FROM node:22-bookworm-slim
+
+ENV NODE_ENV=production \
+    NPM_CONFIG_UPDATE_NOTIFIER=false \
+    NPM_CONFIG_FUND=false \
+    NPM_CONFIG_AUDIT=false
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        openssh-client \
+        python3 \
+        ripgrep \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @openai/codex@{{IMAGE_VERSION}} \
+    && npm cache clean --force
+
+USER node
+WORKDIR /workspace
+
+ENTRYPOINT ["codex"]
+CMD ["--help"]


### PR DESCRIPTION
### Motivation
- Provide a containerized OpenAI Codex CLI so the coding agent can be run reproducibly inside a Docker image. 
- Follow the repository convention for multi-architecture images so the tool is available on `amd64` and `arm64` platforms.

### Description
- Add `codex-cli/mbuild.yml` that defines a multi-arch image for `linux/amd64` and `linux/arm64` with `IMAGE_VERSION: latest`.
- Add `codex-cli/tmpl.Dockerfile` based on `node:22-bookworm-slim` that installs `@openai/codex@{{IMAGE_VERSION}}` globally and common developer tooling such as `git`, `ripgrep`, `python3`, and `build-essential` and sets `ENTRYPOINT` to `codex`.
- Add `codex-cli/README.md` documenting usage, mounting project and config directories, using `OPENAI_API_KEY`, and build/push/deploy instructions via `mbuild`.

### Testing
- Validated `codex-cli/mbuild.yml` contains required keys including `REPO`, `IMAGE_VERSION`, and platform entries `linux/amd64` and `linux/arm64` (succeeded).
- Rendered the Dockerfile template locally and verified the `{{IMAGE_VERSION}}` placeholder resolves to `@openai/codex@latest` (succeeded).
- Attempted `docker build -f /tmp/codex-cli.Dockerfile -t codex-cli:test codex-cli`, but the environment does not have Docker installed (failed).
- Queried `npm view @openai/codex version` but the registry request was blocked with `403 Forbidden` in this environment (failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0102ec6b7083289c9e9dba8b71c72e)